### PR TITLE
Typecasting fix

### DIFF
--- a/modules/db/classes/activerecord.php
+++ b/modules/db/classes/activerecord.php
@@ -935,6 +935,8 @@ class ActiveRecord extends Sql implements IteratorAggregate
 			switch ($field_info['type']) 
 			{
 				case 'decimal':
+				    $value = (int)$value;
+				    break;
 				case 'int':
 				//case 'tinyint':
 				case 'smallint':


### PR DESCRIPTION
Had an issue with decimal fields in database being returned by activerecord as a STRING. Was causing issues when not passing is_numeric() tests

type_cast_field($field, $value)
may need similar changes made to other numeric data types in this method.
